### PR TITLE
return instead of exit

### DIFF
--- a/get_docker_binary.sh
+++ b/get_docker_binary.sh
@@ -25,7 +25,7 @@ if [ ! -e ${DOCKER_BINARY} ] ; then
   
   if [ ! -e ${SKYPORT_TMPDIR}/docker-${DOCKER_VERSION}.tgz ] ; then
     echo "docker binary not found"
-    exit 1
+    return 1
   fi
   
   tar -xvzf ${SKYPORT_TMPDIR}/docker-${DOCKER_VERSION}.tgz -C ${SKYPORT_TMPDIR} docker/docker 

--- a/init.sh
+++ b/init.sh
@@ -8,7 +8,18 @@
 
 if [[ $_ == $0 ]]; then 
   echo "Error: please use command \"source ./init.sh\""
-  exit 1
+  return 1
+fi
+
+docker-compose -v 
+if [[ $? -ne 0 ]]; then
+  echo "docker-compose is missing or not configured.  Follow instructions at https://docs.docker.com/compose/install/ to install"
+  return 1
+fi
+
+if [[ "$(docker-compose -v)" == "docker-compose version 1.8.0"* ]] ; then
+  echo "Version of docker-compose is out of date, follow instructions at https://docs.docker.com/compose/install/"
+  return 1
 fi
   
 


### PR DESCRIPTION
"exit 1" from scripts that are `source`d does not produce the right behavior.  

https://stackoverflow.com/questions/3666846/how-do-you-return-to-a-sourced-bash-script

If the terminal window closes, the user can't see the error message that caused the termination.  

This changes `exit 1` to `return 1` in two of the sourced scripts.
